### PR TITLE
fix: 🩹do not output report header for empty cluster list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Copyright (c) 2024-2025, Oracle and/or its affiliates. All rights reserved.
 All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 1.2.1
+* fix: 🩹do not output report header for empty cluster list
+
 # 1.2.0
 * chore: 👷 update code quality action
 * chore: 🔥 remove version validation single action

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensearch-optic"
-version = "1.2.0"
+version = "1.2.1"
 description = "Opensearch Tools for Indices and Clusters"
 readme = "README.md"
 authors = [

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -31,7 +31,7 @@ def print_cluster_info(cluster_info, no_color, storage_percent_thresholds) -> No
     """
     Prints cluster information
 
-    :param list cluster_dicts: list of dictionaries of cluster information
+    :param list cluster_info: list of dictionaries containing cluster information
     :param bool no_color: disable colored output if value is true
     :param dict storage_percent_thresholds: dict of storage percent thresholds
     :return: None
@@ -52,7 +52,7 @@ def build_cluster_info_table(
     """
     Creates an AsciiTable object populated with cluster information
 
-    :param list cluster_dicts: list of dictionaries of cluster information
+    :param list cluster_info: list of dictionaries containing cluster information
     :param bool no_color: disable colored output if value is true
     :param dict storage_percent_thresholds: dict of storage percent thresholds
     :return: formatted table of cluster information

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -17,32 +17,57 @@ def get_cluster_info(config_info) -> list:
     :return: list of dictionaries containing cluster information
     :rtype: list
     """
-    clusters_dicts = []
+    cluster_info = []
     for cluster in config_info.selected_cluster_objects:
         usage = cluster.storage_percent
         status = cluster.health.status
-        clusters_dicts.append(
+        cluster_info.append(
             {"name": cluster.custom_name, "status": status, "usage": usage}
         )
-    return clusters_dicts
+    return cluster_info
 
 
-def print_cluster_info(cluster_dicts, no_color, storage_percent_thresholds) -> None:
+def print_cluster_info(cluster_info, no_color, storage_percent_thresholds) -> None:
     """
-    Prints Cluster Information
+    Prints cluster information
 
     :param list cluster_dicts: list of dictionaries of cluster information
-    :param bool no_color: whether colored output or not
+    :param bool no_color: disable colored output if value is true
     :param dict storage_percent_thresholds: dict of storage percent thresholds
     :return: None
     :rtype: None
     """
+    table = build_cluster_info_table(cluster_info, no_color, storage_percent_thresholds)
+
+    # only display the table if at least one valid cluster was found
+    if table:
+        print(table.table)
+    else:
+        print("Unable to display cluster information. No valid clusters were selected.")
+
+
+def build_cluster_info_table(
+    cluster_info, no_color, storage_percent_thresholds
+) -> AsciiTable:
+    """
+    Creates an AsciiTable object populated with cluster information
+
+    :param list cluster_dicts: list of dictionaries of cluster information
+    :param bool no_color: disable colored output if value is true
+    :param dict storage_percent_thresholds: dict of storage percent thresholds
+    :return: formatted table of cluster information
+    :rtype: AsciiTable
+    """
+
+    if not cluster_info:
+        return None
+
     optic_color = OpticColor()
     if no_color:
         optic_color.disable_colors()
 
     print_data = [["Cluster", "Status", "Storage Use (%)"]]
-    for stats in cluster_dicts:
+    for stats in cluster_info:
         status = stats["status"]
         match status:
             case "red":
@@ -64,4 +89,4 @@ def print_cluster_info(cluster_dicts, no_color, storage_percent_thresholds) -> N
 
     table = AsciiTable(print_data)
     table.title = "Cluster Info"
-    print(table.table)
+    return table

--- a/src/optic/common/config.py
+++ b/src/optic/common/config.py
@@ -34,7 +34,9 @@ def yaml_load(file_path) -> dict:
 
 
 class ClusterConfig:
-    def __init__(self, cluster_data, selected_clusters, selected_cluster_properties):
+    def __init__(
+        self, cluster_data={}, selected_clusters=[], selected_cluster_properties={}
+    ):
         self._data = cluster_data
         self._selected_clusters = selected_clusters
         self._selected_cluster_properties = selected_cluster_properties

--- a/src/optic/common/config.py
+++ b/src/optic/common/config.py
@@ -35,11 +35,14 @@ def yaml_load(file_path) -> dict:
 
 class ClusterConfig:
     def __init__(
-        self, cluster_data={}, selected_clusters=[], selected_cluster_properties={}
+        self,
+        cluster_data=None,
+        selected_clusters=None,
+        selected_cluster_properties=None,
     ):
-        self._data = cluster_data
-        self._selected_clusters = selected_clusters
-        self._selected_cluster_properties = selected_cluster_properties
+        self._data = cluster_data or {}
+        self._selected_clusters = selected_clusters or []
+        self._selected_cluster_properties = selected_cluster_properties or {}
         self._groups = None
         self._clusters = None
         self._selected_cluster_objects = None

--- a/tests/fixtures/cluster-config.yaml
+++ b/tests/fixtures/cluster-config.yaml
@@ -1,0 +1,26 @@
+clusters:
+  cluster_1:
+    url: https://testurl.com:46
+    username: my_username1
+    password: my_password
+  cluster_2:
+    url: https://myurl.com:9200
+    username: my_username2
+    password: '****'
+  my_cluster:
+    url: https://onlineopensearchcluster.com:634
+    username: my_username3
+    password: '****'
+  cluster_3:
+    url: https://anotherurl.com:82
+    username: my_username4
+    password: '****'
+
+groups:
+  my_group:
+    - cluster_1
+    - cluster_2
+    - cluster_3
+  g2:
+    - cluster_1
+    - my_cluster

--- a/tests/fixtures/optic-settings.yaml
+++ b/tests/fixtures/optic-settings.yaml
@@ -1,0 +1,21 @@
+# File Paths
+settings_file_path: ~/.optic/optic-settings.yaml
+default_cluster_config_file_path: ~/.optic/cluster-config.yaml
+
+# Terminal Customization
+disable_terminal_color: False
+
+# Cluster Info Settings
+default_cluster_info_byte_type: gb
+storage_percent_thresholds:
+  GREEN: 80
+  YELLOW: 85
+  RED: 100
+
+# Index/Alias Info Settings
+default_search_pattern: '*'
+default_index_type_patterns:
+  ISM: '(.*)-ism-(\\d{6})$'
+  ISM_MALFORMED: '(.*)-ism$'
+  SYSTEM: '(^\\..*)$'
+  DATED: '(.*)-(\\d{4})\\.(\\d{2})\\.(\\d{2})$'


### PR DESCRIPTION
# Description
Fixes #4

Behavior before fix: 
```
7398 ➜ optic cluster info --clusters not_a_valid_cluster_name
not_a_valid_cluster_name is not present in cluster configuration information
+Cluster Info------+-----------------+
| Cluster | Status | Storage Use (%) |
+---------+--------+-----------------+
7398 ➜
```

Behavior after fix: 
```
7399 ➜ optic cluster info  --clusters not_a_valid_cluster_name
not_a_valid_cluster_name is not present in cluster configuration information
Unable to display cluster information. No valid clusters were selected.
7400 ➜ 
```
## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created two new unit tests: 
-  `TestClusterService.test_build_cluster_info_table_valid_cluster`
-  `TestClusterService.test_build_cluster_info_table_invalid_cluster`


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
