### PR TITLE
feat: 🥅 add retry logic to OpenSearch API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Copyright (c) 2024-2025, Oracle and/or its affiliates. All rights reserved.
 All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-# 1.4.7
+# 1.5.0
 * feat: 🥅 add retry logic to OpenSearch API calls 
 * fix: 🩹 moved API call notification messages to correctly report order of actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Copyright (c) 2024-2025, Oracle and/or its affiliates. All rights reserved.
 All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 1.4.7
+* feat: 🥅 add retry logic to OpenSearch API calls 
+* fix: 🩹 moved API call notification messages to correctly report order of actions
+
 # 1.4.6
 * docs: 📝 add quick start section
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensearch-optic"
-version = "1.4.7"
+version = "1.5.0"
 description = "Opensearch Tools for Indices and Clusters"
 readme = "README.md"
 authors = [
@@ -53,7 +53,8 @@ dev = [
     "isort",
     "pep8-naming",
     "pre-commit",
-    "pytest-mock"
+    "pytest-mock",
+    "requests-mock"
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensearch-optic"
-version = "1.4.6"
+version = "1.4.7"
 description = "Opensearch Tools for Indices and Clusters"
 readme = "README.md"
 authors = [

--- a/src/optic/cluster/cluster.py
+++ b/src/optic/cluster/cluster.py
@@ -132,7 +132,6 @@ class Cluster:
         :rtype: list
         """
         if not self._index_list:
-            print("Getting cluster index list for", self.custom_name)
             index_list = []
             api = OpenSearchAction(
                 base_url=self.base_url,
@@ -152,6 +151,7 @@ class Cluster:
                 for write_target in alias.write_targets:
                     index_to_write_target[write_target.index] = True
 
+            print("Getting cluster index list for", self.custom_name)
             for index_info in api.response:
                 index_list.append(
                     Index(
@@ -177,7 +177,6 @@ class Cluster:
         :rtype: list
         """
         if not self._alias_list:
-            print("Getting cluster alias list for", self.custom_name)
             alias_list = []
             api = OpenSearchAction(
                 base_url=self.base_url,
@@ -231,6 +230,8 @@ class Cluster:
               ]
             }
             """
+
+            print("Getting cluster alias list for", self.custom_name)
             alias_to_indices = {}
             for alias_info in api.response:
                 if alias_info["alias"] not in alias_to_indices.keys():

--- a/src/optic/common/api.py
+++ b/src/optic/common/api.py
@@ -4,23 +4,55 @@
 # ** Licensed under the Universal Permissive License v 1.0
 # ** as shown at https://oss.oracle.com/licenses/upl/
 
+import logging
+
 import requests
 import urllib3
+from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
+from urllib3.util.retry import Retry
 
 from optic.common.exceptions import OpticAPIError
+
+logging.basicConfig(level=logging.INFO)
 
 urllib3.disable_warnings()
 
 
 class OpenSearchAction:
-    def __init__(self, base_url="", usr="", pwd=None, verify_ssl=True, query=""):
+    def __init__(
+        self,
+        base_url="",
+        query="",
+        retries=3,
+        backoff_factor=2,
+        status_forcelist=(500, 502, 503, 504),
+        usr="",
+        pwd=None,
+        verify_ssl=True,
+    ):
+        """
+        Wraps the methods required to execute REST calls against the OpenSearch API.
+        Args:
+            base_url (str): The URL to send the request to
+            query (str): additional string added to the end of base_url
+            retries (int): Maximum number of retries
+            backoff_factor (float): Backoff factor to apply between retries in seconds
+            status_forcelist (tuple): HTTP status codes to retry on
+            usr (str): username to be used in BasicAuth header
+            pwd (str): password to be used in BasicAuth header
+            verify_ssl (boolean): set SSL verification mode
+
+        """
+
         self.base_url = base_url
+        self.query = query
+        self.retries = retries
+        self.backoff_factor = backoff_factor
+        self.status_forcelist = status_forcelist
         self.usr = usr
         self.pwd = pwd
         self.verify_ssl = verify_ssl
-        self.query = query
-
         self._response = None
 
     @property
@@ -31,18 +63,35 @@ class OpenSearchAction:
         :return: JSON-like object with response data
         :rtype: list | dict
         """
+
         if not self._response:
+            url = self.base_url + self.query
+            logging.debug(
+                f"creating REST request to {url} with "
+                f"{self.retries} retries, backoff {self.backoff_factor}, and ssl verify {self.verify_ssl}"
+            )
+            basic_auth = HTTPBasicAuth(self.usr, self.pwd)
+            retry_strategy = Retry(
+                total=self.retries,
+                backoff_factor=self.backoff_factor,
+                status_forcelist=self.status_forcelist,
+            )
+            session = requests.Session()
+            session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
+            session.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+
             try:
-                basic = HTTPBasicAuth(self.usr, self.pwd)
-                self._response = requests.get(
-                    self.base_url + self.query,
+                self._response = session.get(
+                    url,
                     verify=self.verify_ssl,
-                    auth=basic,
+                    auth=basic_auth,
                     timeout=6,
                 )
                 self._response.raise_for_status()
             except requests.exceptions.RequestException as err:
-                raise OpticAPIError(str(err)) from err
+                raise OpticAPIError(
+                    f"Request failed after {self.retries} retries {str(err)}"
+                ) from err
 
             self._response = self._response.json()
 

--- a/src/optic/common/api.py
+++ b/src/optic/common/api.py
@@ -28,7 +28,7 @@ class OpenSearchAction:
         backoff_factor=2,
         status_forcelist=(500, 502, 503, 504),
         usr="",
-        pwd=None,
+        pwd="",
         verify_ssl=True,
     ):
         """

--- a/src/optic/common/api.py
+++ b/src/optic/common/api.py
@@ -27,8 +27,8 @@ class OpenSearchAction:
         retries=3,
         backoff_factor=2,
         status_forcelist=(500, 502, 503, 504),
-        usr="",
-        pwd="",
+        usr=None,
+        pwd=None,
         verify_ssl=True,
     ):
         """
@@ -50,8 +50,12 @@ class OpenSearchAction:
         self.retries = retries
         self.backoff_factor = backoff_factor
         self.status_forcelist = status_forcelist
-        self.usr = usr
-        self.pwd = pwd
+        self.usr = (
+            usr or str()
+        )  # Requests 3.0.0 will no longer support None as a username
+        self.pwd = (
+            pwd or str()
+        )  # Requests 3.0.0 will no longer support None as a password
         self.verify_ssl = verify_ssl
         self._response = None
 

--- a/src/optic/common/api.py
+++ b/src/optic/common/api.py
@@ -89,9 +89,17 @@ class OpenSearchAction:
                 )
                 self._response.raise_for_status()
             except requests.exceptions.RequestException as err:
-                raise OpticAPIError(
-                    f"Request failed after {self.retries} retries {str(err)}"
-                ) from err
+                # Check if retries were exhausted
+                if err.args and isinstance(
+                    err.args[0], urllib3.exceptions.MaxRetryError
+                ):
+                    raise OpticAPIError(
+                        f"Request failed after {self.retries} retries {err}"
+                    ) from err
+                else:
+                    raise OpticAPIError(
+                        f"did not attempt to retry error: {err}"
+                    ) from err
 
             self._response = self._response.json()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,12 +64,8 @@ class TestOpenSearchActionClass:
         ):
             action = OpenSearchAction(
                 base_url="http://example.com/optic",
-                query="test",
                 retries=5,
                 backoff_factor=backoff_factor,
-                usr="u",
-                pwd="p",
-                verify_ssl=False,
             )
             result = action.response
 
@@ -114,11 +110,7 @@ class TestOpenSearchActionClass:
             with pytest.raises(OpticAPIError) as exc_info:
                 action = OpenSearchAction(
                     base_url="http://example.com/optic",
-                    query="test",
                     retries=retries,  # force exhaustion
-                    usr="u",
-                    pwd="p",
-                    verify_ssl=False,
                 )
                 _ = (
                     action.response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,137 @@
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from urllib3.response import HTTPResponse
+
+from optic.common.api import OpenSearchAction
+from optic.common.exceptions import OpticAPIError
+
+
+class TestOpenSearchActionClass:
+    def _http_response(self, status: int, body_bytes: bytes):
+        """
+        Create a mock HTTPResponse that works with requests/urllib3 streaming.
+        """
+        return HTTPResponse(
+            body=BytesIO(body_bytes), status=status, preload_content=False
+        )
+
+    def test_successful_request(self, mocker):
+        """
+        When OpenSearchAction receives a valid response, and a status code of 200, it should not raise an Exception
+        """
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"request": "valid"}
+
+        api = OpenSearchAction(base_url="http://example.com/optic")
+        mocker.patch("requests.Session.get", return_value=mock_response)
+
+        assert api.response == {"request": "valid"}
+
+    # attempt 4 different backoff_factors to ensure the number is being correctly handled by OpenSearchAction
+    @pytest.mark.parametrize("backoff_factor", [0.5, 1, 2, 5])
+    def test_retry_failure_until_success(self, backoff_factor):
+        """
+        verify that failed OpenSearchAction HTTP requests are retried, and that
+        after the initial immediate retry, the requests.Session module honors the
+        configurable backoff method to delay subsequent retries for the expected number
+        of seconds
+        """
+
+        # make 4 total requests, 3 that should trigger a retry, and then the final request should simulate a success
+        requests = [
+            self._http_response(502, b'{"error":"cant get through this gateway"}'),
+            self._http_response(500, b'{"error":"i am internalizing this error"}'),
+            self._http_response(503, b'{"error":"this service is unavailable!"}'),
+            self._http_response(200, b'{"result":"finally! a success"}'),
+        ]
+
+        # store how many seconds each retry requested the time.sleep method to wait
+        requested_sleep_seconds = []
+
+        def _patched_sleep(seconds):
+            requested_sleep_seconds.append(seconds)
+
+        with (
+            patch(
+                "urllib3.connectionpool.HTTPConnectionPool._make_request",
+                side_effect=requests,
+            ),
+            patch("time.sleep", side_effect=_patched_sleep),
+        ):
+            action = OpenSearchAction(
+                base_url="http://example.com/optic",
+                query="test",
+                retries=5,
+                backoff_factor=backoff_factor,
+                usr="u",
+                pwd="p",
+                verify_ssl=False,
+            )
+            result = action.response
+
+        # Assert final response
+        assert result == {"result": "finally! a success"}
+
+        # Exponential backoff: backoff_factor * (2 ** retry_number)
+        # first retry does not request a sleep before retrying
+        # last request is successful
+        expected_sleep_seconds = [
+            backoff_factor * (2**i) for i in range(1, len(requests) - 1)
+        ]
+        assert requested_sleep_seconds == expected_sleep_seconds
+
+    # attempt 4 different values for retries to ensure the number is being correctly handled by OpenSearchAction
+    @pytest.mark.parametrize("retries", [4, 14, 28, 36])
+    def test_retry_failure_until_exhausted(self, retries):
+        """
+        verify that failed OpenSearchAction HTTP requests are retried, and that
+        a OpticAPIError exception is raised after exhausting the maximum number of retries
+        """
+
+        # in this test, we do not want to wait for the time.sleep method to pause execution
+        def _patched_sleep(seconds):
+            pass
+
+        # make as many failed responses as needed in order to exhaust the retry count
+        # first attempt is not considered a retry
+        requests = [
+            self._http_response(502, b'{"error":"cant get through this gateway"}')
+            for _ in range(retries + 1)
+        ]
+
+        with (
+            patch(
+                "urllib3.connectionpool.HTTPConnectionPool._make_request",
+                side_effect=requests,
+            ) as mock_make_request,
+            patch("time.sleep", side_effect=_patched_sleep),
+        ):
+
+            with pytest.raises(OpticAPIError) as exc_info:
+                action = OpenSearchAction(
+                    base_url="http://example.com/optic",
+                    query="test",
+                    retries=retries,  # force exhaustion
+                    usr="u",
+                    pwd="p",
+                    verify_ssl=False,
+                )
+                _ = (
+                    action.response
+                )  # response is a property, so it needs to be accessed to execute
+
+        # Assert type
+        assert isinstance(exc_info.value, OpticAPIError)
+
+        # Assert retry count shows up in message
+        assert f"after {retries} retries" in str(exc_info.value)
+
+        # Assert the root cause text is included
+        assert "502 error responses" in str(exc_info.value)
+
+        # Assert the _make_request method was called the expected number of times (first call is not considered a retry)
+        assert mock_make_request.call_count == retries + 1


### PR DESCRIPTION
# Description

* feat: 🥅 add retry logic to OpenSearch API calls
* fix: 🩹 moved API call notification messages to correctly report order of actions
* test: ✅ successful request, retry until success, and retry exhaustion tests created
* fix: 🩹 None is no longer supported as default for password

Adds retry logic for REST calls to the OpenSearch API to prevent `optic` from stopping when a brief communication issue with the OpenSearch cluster exists.  It will only retry the following status codes: 
* 500, 502, 503, 504

For these status codes, the request will be retried 3 times, with a backoff factor of 2. Other status codes will not be retried, but the error will be caught gracefully. 

Created issue #29 to support user customization of the retry and backoff factor settings. The list of status codes that will force a retry should also be customizable as part of #29. 

Fixes #9 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] changed URL and Login data within `cluster-config.yml` to simulate connection issues. 
- [X] locally executed pytest to ensure new unittests were functioning as expected

**Test Configuration**:
Created `mock` tests for simulating HTTP status codes that should be retried. Tests exist to validate that successful requests are not retried, a specific subset of status codes are retried and either finally succeed, or fail gracefully if the retry limit is exceeded. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
