### PR TITLE
💥 Breaking Change 💥 remove CLI options that were not intended for CLI interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ this file. This project adheres to [Semantic Versioning](http://semver.org/).
 * fix: 🗑️ remove CLI options that were not intended for CLI interface
   * storage_percent_thresholds
   * index_type_patterns
+* refactor: 🚸 rename Cluster attribute `creds` to `auth`
 * refactor: 🏗️ Cluster objects are updated with all optic-settings, instead of only cli options
   * enables additional configuration options in optic-settings.yaml that are not part of cli
 * refactor: 🏗️ get_cluster_info, get_index_info, get_alias_info now use Cluster object as argument instead of ClusterConfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Copyright (c) 2024-2025, Oracle and/or its affiliates. All rights reserved.
 All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 2.0.0
+* refactor:! 💥 rename CLI options to better align with functionality
+* feat: 🚸 cli defaults now show settings defined in optic-settings.yaml
+* feat: 🚸 optic init now allows for specifying custom destination for created configuration files
+* fix: 🗑️ remove CLI options that were not intended for CLI interface
+  * storage_percent_thresholds
+  * index_type_patterns
+* refactor: 🏗️ Cluster objects are updated with all optic-settings, instead of only cli options
+  * enables additional configuration options in optic-settings.yaml that are not part of cli
+* refactor: 🏗️ get_cluster_info, get_index_info, get_alias_info now use Cluster object as argument instead of ClusterConfig
+* refactor: 🧑‍💻 shorten Cluster object custom_name attribute to name
+* refactor: 🧑‍💻 Settings class renamed to OpticSettings to align with filename and ClusterConfig class name 
+* refactor: 🧑‍💻 index_type_dict attribute in IndexInfo object renamed to index_type_patterns to match configuration setting
+
+
 # 1.5.1
 * chore: 🔧 updated metadata to include all changes from 1.5.0 🤦🏼‍♂️ 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,19 @@ All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 # 2.0.0
-* refactor:! 💥 rename CLI options to better align with functionality
-* feat: 🚸 cli defaults now show settings defined in optic-settings.yaml
-* feat: 🚸 optic init now allows for specifying custom destination for created configuration files
-* fix: 🗑️ remove CLI options that were not intended for CLI interface
+* fix:! 💥 Breaking Change 💥 remove CLI options that were not intended for CLI interface
   * storage_percent_thresholds
   * index_type_patterns
+* feat: 🚸 cli defaults now show settings defined in optic-settings.yaml
+* feat: 🚸 optic init now allows for specifying custom destination for created configuration files
 * refactor: 🚸 rename Cluster attribute `creds` to `auth`
-* refactor: 🚸 shorten OpenSearchAction attribute base_url to url
+* refactor: 🚸 shorten OpenSearchAction attribute `base_url` to `url`
 * refactor: 🏗️ Cluster objects are updated with all optic-settings, instead of only cli options
-  * enables additional configuration options in optic-settings.yaml that are not part of cli
-* refactor: 🏗️ get_cluster_info, get_index_info, get_alias_info now use Cluster object as argument instead of ClusterConfig
-* refactor: 🧑‍💻 shorten Cluster object custom_name attribute to name
-* refactor: 🧑‍💻 Settings class renamed to OpticSettings to align with filename and ClusterConfig class name 
-* refactor: 🧑‍💻 index_type_dict attribute in IndexInfo object renamed to index_type_patterns to match configuration setting
+  * enables additional configuration options in `optic-settings.yaml` that are not part of cli
+* refactor: 🏗️ `get_cluster_info`, `get_index_info`, `get_alias_info` now use `Cluster` object as argument instead of ClusterConfig
+* refactor: 🧑‍💻 shorten Cluster object `custom_name` attribute to `name`
+* refactor: 🧑‍💻 `Settings` class renamed to `OpticSettings` to align with filename and `ClusterConfig` class name 
+* refactor: 🧑‍💻 `index_type_dict` attribute in `IndexInfo` object renamed to `index_type_patterns` to match configuration setting
 
 
 # 1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ this file. This project adheres to [Semantic Versioning](http://semver.org/).
   * storage_percent_thresholds
   * index_type_patterns
 * refactor: 🚸 rename Cluster attribute `creds` to `auth`
+* refactor: 🚸 shorten OpenSearchAction attribute base_url to url
 * refactor: 🏗️ Cluster objects are updated with all optic-settings, instead of only cli options
   * enables additional configuration options in optic-settings.yaml that are not part of cli
 * refactor: 🏗️ get_cluster_info, get_index_info, get_alias_info now use Cluster object as argument instead of ClusterConfig

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ groups:
 * A default settings file provided below <mark>can be generated using the `optic init` command</mark> (see: [Initialize OPTIC](#initialize-optic)):
 ```yaml
 # File Paths
-cluster_config_file: ~/.optic/cluster-config.yaml
+cluster_config_file_path: ~/.optic/cluster-config.yaml
 
 # Terminal Customization
 disable_terminal_color: False
@@ -375,7 +375,7 @@ selected_clusters = optic.get_selected_clusters(
 cluster_info = optic.get_cluster_info(selected_clusters)
 
 print("CLUSTER INFORMATION")
-print(json.dumps(cluster_info_response, indent=3))
+print(json.dumps(cluster_info, indent=3))
 ```
 ### get_index_info()
 Properties specific to `get_index_info` are:
@@ -482,7 +482,7 @@ for cluster in selected_clusters:
 index_info = optic.get_index_info(selected_clusters, filters, sort_by)
 
 print("INDEX INFORMATION")
-print(json.dumps(index_info_response, indent=3))
+print(json.dumps(index_info, indent=3))
 ```
 
 ### get_alias_info()
@@ -498,14 +498,14 @@ import json
 cluster = optic.Cluster(**{
     "name": "stage-jfk",
     "url": "https://stage-jfk.example.com:9200",
-    "auth" : {"password": "*******",, "username": "oracle"},
+    "auth" : {"password": "*******", "username": "oracle"},
     "search_pattern": '*air*'
     }
 )
 
 alias_info = optic.get_alias_info([cluster])
 print("ALIAS INFORMATION")
-print(json.dumps(cluster_info_response, indent=3))
+print(json.dumps(alias_info, indent=3))
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ import json
 
 cluster = optic.Cluster(**{
     "name": "stage-jfk",
-    "base_url": "https://stage-jfk.example.com:9200",
+    "url": "https://stage-jfk.example.com:9200",
     "auth" : {"password": "*******",, "username": "oracle"},
     "search_pattern": '*air*'
     }

--- a/README.md
+++ b/README.md
@@ -46,24 +46,9 @@ optic init
 ```
 
 * Edit the generated `~/.optic/cluster-config.yaml` file to add your OpenSearch clusters information.
-```yaml
-clusters:
-  cluster_1:
-    url: https://myurl01.com:9200
-    username: my_username1
-    password: my_password1
-    verify_ssl: true
-  cluster_2:
-    url: https://myurl02.com:9200
-    username: my_username2
-    password: my_password2
-groups:
-  cluster_group:
-    - cluster_1
-    - cluster_2
-```
 
-* Start using OPTIC. Example commands to get you started:
+
+#### Example commands to get you started:
 
 Display cluster information from cluster named `cluster_1`:
 ```sh
@@ -149,30 +134,46 @@ in [Settings](#settings-file) and [Using the OPTIC CLI](#using-the-optic-cli))
 ```yaml
 clusters:
   cluster_1:
-    url: https://testurl.com:9100
+    url: https://testurl.com:46
     username: my_username1
     password: my_password
-    verify_ssl: true
   cluster_2:
     url: https://myurl.com:9200
     username: my_username2
     password: '****'
-  my_cluster:
-    url: https://onlineopensearchcluster.com:9300
-    username: my_username3
-    password: '****'
   cluster_3:
-    url: https://anotherurl.com:9400
+    url: https://anotherurl.com:82
     username: my_username4
     password: '****'
+  cluster_4:
+    url: https://anotherurl2.com:82
+    username: my_username5
+    password: '****'
+  cluster_5:
+    url: https://anotherurl3.com:82
+    username: my_username6
+    password: '****'
+  my_cluster:
+    url: https://onlineopensearchcluster.com:634
+    username: my_username3
+    password: '****'
+  dev_cluster:
+    url: https://offlineopensearchcluster.com:634
+    username: my_username3
+    password: '****'
+
 groups:
-  my_cluster_group:
+  dev:
+    - my_cluster
+    - dev_cluster
+  stage:
     - cluster_1
     - cluster_2
     - cluster_3
-  g2:
-    - cluster_1
-    - my_cluster
+  production:
+    - cluster_4
+    - cluster_5
+
 ```
 * The verify_ssl field is optional (default is true if omitted)
 * The groups field is optional
@@ -187,22 +188,21 @@ groups:
 * A default settings file provided below <mark>can be generated using the `optic init` command</mark> (see: [Initialize OPTIC](#initialize-optic)):
 ```yaml
 # File Paths
-settings_file_path: ~/.optic/optic-settings.yaml
-default_cluster_config_file_path: ~/.optic/cluster-config.yaml
+cluster_config_file: ~/.optic/cluster-config.yaml
 
 # Terminal Customization
 disable_terminal_color: False
 
 # Cluster Info Settings
-default_cluster_info_byte_type: gb
+byte_type: gb
 storage_percent_thresholds:
   GREEN: 80
   YELLOW: 85
   RED: 100
 
 # Index/Alias Info Settings
-default_search_pattern: '*'
-default_index_type_patterns:
+search_pattern: '*'
+index_type_patterns:
   ISM: '(.*)-ism-(\d{6})$'
   ISM_MALFORMED: '(.*)-ism$'
   SYSTEM: '(^\..*)$'
@@ -231,7 +231,7 @@ optic <tool_domain> <tool_name> --help
 ```
 To run OPTIC with an alternate settings file path, enter:
 ```
-optic --settings-path <custom_file_path> <tool_domain> <tool_name>
+optic --settings-file <custom_file_path> <tool_domain> <tool_name>
 ```
 
 To display information about clusters from a group of clusters called `my_cluster_group`, enter:

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ optic <tool_domain> <tool_name> --help
 ```
 To run OPTIC with an alternate settings file path, enter:
 ```
-optic --settings-file <custom_file_path> <tool_domain> <tool_name>
+optic --settings <custom_file_path> <tool_domain> <tool_name>
 ```
 
 To display information about clusters from a group of clusters called `my_cluster_group`, enter:

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ import json
 cluster = optic.Cluster(**{
     "name": "stage-jfk",
     "base_url": "https://stage-jfk.example.com:9200",
-    "creds" : {"password": "*******",, "username": "oracle"},
+    "auth" : {"password": "*******",, "username": "oracle"},
     "search_pattern": '*air*'
     }
 )

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   * [get_alias_info()](#get_alias_info)
 
 ## What is OPTIC?
-OPTIC (OpenSearch Tools for Indices and Clusters) is a Python language tool suite designed to offer OpenSearch Engineers
+OPTIC (OpenSearch Tools for Indices and Clusters) is a Python language tool suite designed to offer OpenSearch users
 utilities to troubleshoot, analyze, and make changes to OpenSearch clusters and indices.  OPTIC is designed to offer
 both a rich command line experience and a library that can be called from other pieces of code.
 
@@ -50,26 +50,26 @@ optic init
 
 #### Example commands to get you started:
 
-Display cluster information from cluster named `cluster_1`:
+Display cluster information from the cluster named `cluster_1`:
 ```sh
 optic cluster info -c cluster_1
 ```
-Display cluster information from group of clusters named `cluster_group`:
+Display cluster information from the group of clusters named `cluster_group`:
 ```sh
 optic cluster info -c cluster_group
 ```
 
-Find all indexes from cluster `cluster_1`:
+Find all indexes from the cluster `cluster_1`:
 ```sh
 optic index info -c cluster_1
 ```
 
-Find indexes from cluster `cluster_1` that match the pattern `first-index*`:
+Find indexes from the cluster `cluster_1` that match the pattern `first-index*`:
 ```sh
 optic index info -c cluster_1 -p "first-index*"
 ```
 
-Find aliases from cluster `cluster_1` that match the pattern `first-alias*`:
+Find aliases from the cluster `cluster_1` that match the pattern `first-alias*`:
 ```sh
 optic index info -c cluster_1 -p "first-alias*"
 ```
@@ -133,46 +133,49 @@ in [Settings](#settings-file) and [Using the OPTIC CLI](#using-the-optic-cli))
 * A sample configuration file provided below <mark>can be generated using the `optic init` command</mark> (see: [Initialize OPTIC](#initialize-optic)):
 ```yaml
 clusters:
-  cluster_1:
-    url: https://testurl.com:46
-    username: my_username1
+  prod-lga:
+    url: https://prod-lga.example.com:9200
+    username: oracle
     password: my_password
-  cluster_2:
-    url: https://myurl.com:9200
-    username: my_username2
+  prod-jfk:
+    url: https://prod-jfk.example.com:9200
+    username: oracle
     password: '****'
-  cluster_3:
-    url: https://anotherurl.com:82
-    username: my_username4
+  prod-sfo:
+    url: https://prod-sfo.example.com:9200
+    username: oracle
     password: '****'
-  cluster_4:
-    url: https://anotherurl2.com:82
-    username: my_username5
+  stage-lga:
+    url: https://stage-lga.example.com:9200
+    username: oracle
+    password: my_password
+  stage-jfk:
+    url: https://stage-jfk.example.com:9200
+    username: oracle
     password: '****'
-  cluster_5:
-    url: https://anotherurl3.com:82
-    username: my_username6
+  stage-sfo:
+    url: https://stage-sfo.example.com:9200
+    username: oracle
     password: '****'
-  my_cluster:
-    url: https://onlineopensearchcluster.com:634
-    username: my_username3
+  dev-lga:
+    url: https://dev-lga.example.com:9200
+    username: oracle
+    password: my_password
+  dev-jfk:
+    url: https://dev-jfk.example.com:9200
+    username: oracle
     password: '****'
-  dev_cluster:
-    url: https://offlineopensearchcluster.com:634
-    username: my_username3
-    password: '****'
-
 groups:
   dev:
-    - my_cluster
-    - dev_cluster
+    - dev-lga
+    - dev-jfk
   stage:
-    - cluster_1
-    - cluster_2
-    - cluster_3
+    - stage-lga
+    - stage-jfk
+    - stage-sfo
   production:
-    - cluster_4
-    - cluster_5
+    - prod-lga
+    - prod-jfk
 
 ```
 * The verify_ssl field is optional (default is true if omitted)
@@ -304,65 +307,81 @@ The recommended way to call OPTIC functionality from code is generally as follow
 * Call the desired action w/ the ClusterConfig object as an argument and use any returned data as desired
 
 ### get_cluster_info()
-Properties specific to get_cluster_info are:
-
-    byte_type - specify a storage unit for the query (mb or gb)
-
 The sample code below queries cluster information from a selection of clusters and prints the results:
 ```python
 import optic
 import json
 
-cluster_info = {
+cluster_config = {
     "clusters": {
-        "cluster_1": {
-            "url" : "https://exampleurl.com",
-            "username": "example_username",
-            "password": "****",
-            "verify_ssl": False
+        "prod-lga": {
+            "password": "*******",
+            "url": "https://prod-lga.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_2": {
-            "url" : "https://exampleurl2.com",
-            "username": "example_username",
-            "password": "****",
+        "prod-jfk": {
+            "password": "*******",
+            "url": "https://prod-jfk.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_3": {
-            "url" : "https://exampleurl3.com",
-            "username": "example_username",
-            "password": "****",
+        "prod-sfo": {
+            "password": "*******",
+            "url": "https://prod-sfo.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_4": {
-            "url" : "https://exampleurl4.com",
-            "username": "example_username",
-            "password": "****",
-        }
+        "stage-lga": {
+            "password": "*******",
+            "url": "https://stage-lga.example.com:9200",
+            "username": "oracle",
+        },
+        "stage-jfk": {
+            "password": "*******",
+            "url": "https://stage-jfk.example.com:9200",
+            "username": "oracle",
+        },
+        "stage-sfo": {
+            "password": "*******",
+            "url": "https://stage-sfo.example.com:9200",
+            "username": "oracle",
+        },
+         "dev-lga": {
+            "password": "*******",
+            "url": "https://dev-lga.example.com:9200",
+            "username": "oracle",
+        },
+        "dev-jfk": {
+            "password": "*******",
+            "url": "https://dev-jfk.example.com:9200",
+            "username": "oracle",
+        },
+        "dev-sfo": {
+            "password": "*******",
+            "url": "https://dev-sfo.example.com:9200",
+            "username": "oracle",
+        },
     },
     "groups": {
-        "group1": [
-            "cluster_3",
-            "cluster_4"
-        ],
-        "g2": [
-            "cluster_2",
-            "cluster_3"
-        ]
-    }
+        "prod": ["prod-lga", "prod-jfk", "prod-sfo"],
+        "stage": ["stage-lga", "stage-jfk", "stage-sfo"],
+        "dev": ["dev-lga", "dev-jfk", "dev-sfo"],
+    },
 }
-desired_clusters = ["cluster_3", "g2"]
-desired_cluster_properties = {
-    "byte_type": "mb"
-}
-cluster_generator = optic.ClusterConfig(cluster_info, desired_clusters, desired_cluster_properties)
 
-cluster_info_response = optic.get_cluster_info(cluster_generator)
+
+cluster_selection = ["prod", "dev-sfo"]
+selected_clusters = optic.get_selected_clusters(
+    optic.ClusterConfig(cluster_config), cluster_selection
+)
+cluster_info = optic.get_cluster_info(selected_clusters)
+
 print("CLUSTER INFORMATION")
 print(json.dumps(cluster_info_response, indent=3))
 ```
 ### get_index_info()
-Properties specific to get_index_info are:
+Properties specific to `get_index_info` are:
 
-    index_search_pattern - specify a glob search pattern for the query
-    index_types_dict - specify a dictionary with index_type_name -> regular_expression pairs
+    search_pattern - specify a glob search pattern for the query
+    index_type_patterns - specify a dictionary with index_type_name -> regular_expression pairs
 
 Additionally, get_index_info can support two more <mark>optional</mark> parameters that allow for more advanced filtering and sorting of data:
 
@@ -390,123 +409,101 @@ The sample code below queries index information from a cluster and prints the re
 import optic
 import json
 
-cluster_info = {
+cluster_config = {
     "clusters": {
-        "cluster_1": {
-            "url" : "https://exampleurl.com",
-            "username": "example_username",
-            "password": "****",
-            "verify_ssl": False
+        "prod-lga": {
+            "password": "*******",
+            "url": "https://prod-lga.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_2": {
-            "url" : "https://exampleurl2.com",
-            "username": "example_username",
-            "password": "****",
+        "prod-jfk": {
+            "password": "*******",
+            "url": "https://prod-jfk.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_3": {
-            "url" : "https://exampleurl3.com",
-            "username": "example_username",
-            "password": "****",
+        "prod-sfo": {
+            "password": "*******",
+            "url": "https://prod-sfo.example.com:9200",
+            "username": "oracle",
         },
-        "cluster_4": {
-            "url" : "https://exampleurl4.com",
-            "username": "example_username",
-            "password": "****",
-        }
+        "stage-lga": {
+            "password": "*******",
+            "url": "https://stage-lga.example.com:9200",
+            "username": "oracle",
+        },
+        "stage-jfk": {
+            "password": "*******",
+            "url": "https://stage-jfk.example.com:9200",
+            "username": "oracle",
+        },
+        "stage-sfo": {
+            "password": "*******",
+            "url": "https://stage-sfo.example.com:9200",
+            "username": "oracle",
+        },
+         "dev-lga": {
+            "password": "*******",
+            "url": "https://dev-lga.example.com:9200",
+            "username": "oracle",
+        },
+        "dev-jfk": {
+            "password": "*******",
+            "url": "https://dev-jfk.example.com:9200",
+            "username": "oracle",
+        },
+        "dev-sfo": {
+            "password": "*******",
+            "url": "https://dev-sfo.example.com:9200",
+            "username": "oracle",
+        },
     },
     "groups": {
-        "group1": [
-            "cluster_3",
-            "cluster_4"
-        ],
-        "g2": [
-            "cluster_2",
-            "cluster_3"
-        ]
-    }
+        "prod": ["prod-lga", "prod-jfk", "prod-sfo"],
+        "stage": ["stage-lga", "stage-jfk", "stage-sfo"],
+        "dev": ["dev-lga", "dev-jfk", "dev-sfo"],
+    },
 }
-desired_clusters = ["cluster_1"]
-filters = {
-    "write_alias_only": None,
-    "min_age": 10,
-    "max_age": None,
-    "min_index_size": None,
-    "max_index_size": None,
-    "min_shard_size": "100kb",
-    "max_shard_size": None,
-    "min_doc_count": None,
-    "max_doc_count": None,
-    "type_filter": ["SYSTEM"],
-}
+
+cluster_selection = ["stage", "prod-jfk"]
+selected_clusters = optic.get_selected_clusters(
+    optic.ClusterConfig(cluster_config), cluster_selection
+)
+
 sort_by = ["age"]
-types_dict = {
-  "ISM": '(.*)-ism-(\\d{6})$',
-  "ISM_MALFORMED": '(.*)-ism$',
-  "SYSTEM": '(^\\..*)$',
-  "DATED": '(.*)-(\\d{4})\\.(\\d{2})\\.(\\d{2})$',
+filters = {'max_age': 10}
+optic_settings = {
+    'search_pattern': '*departure*',
+    'index_type_patterns': {'ISM': '(.*)-ism-(\\d{6})$'}
 }
-desired_cluster_properties = {
-    "index_search_pattern": "*",
-    "index_types_dict": types_dict,
-}
-cluster_generator = optic.ClusterConfig(cluster_info, desired_clusters, desired_cluster_properties)
-index_info_response = optic.get_index_info(cluster_generator, filters, sort_by)
+
+for cluster in selected_clusters:
+    optic.configure_cluster(cluster, optic_settings)
+
+index_info = optic.get_index_info(selected_clusters, filters, sort_by)
+
 print("INDEX INFORMATION")
 print(json.dumps(index_info_response, indent=3))
 ```
 
 ### get_alias_info()
-Properties specific to get_alias_info are:
+Properties specific to `get_alias_info` are:
 
-    index_search_pattern - specify a glob search pattern for the query
+    search_pattern - specify a glob search pattern for the query
 
 The sample code below queries alias information from a selection of clusters and prints the results:
 ```python
 import optic
 import json
 
-cluster_info = {
-    "clusters": {
-        "cluster_1": {
-            "url" : "https://exampleurl.com",
-            "username": "example_username",
-            "password": "****",
-            "verify_ssl": False
-        },
-        "cluster_2": {
-            "url" : "https://exampleurl2.com",
-            "username": "example_username",
-            "password": "****",
-        },
-        "cluster_3": {
-            "url" : "https://exampleurl3.com",
-            "username": "example_username",
-            "password": "****",
-        },
-        "cluster_4": {
-            "url" : "https://exampleurl4.com",
-            "username": "example_username",
-            "password": "****",
-        }
-    },
-    "groups": {
-        "group1": [
-            "cluster_3",
-            "cluster_4"
-        ],
-        "g2": [
-            "cluster_2",
-            "cluster_3"
-        ]
+cluster = optic.Cluster(**{
+    "name": "stage-jfk",
+    "base_url": "https://stage-jfk.example.com:9200",
+    "creds" : {"password": "*******",, "username": "oracle"},
+    "search_pattern": '*air*'
     }
-}
-desired_clusters = ["cluster_3", "g2"]
-desired_cluster_properties = {
-    "index_search_pattern": "*",
-}
-cluster_generator = optic.ClusterConfig(cluster_info, desired_clusters, desired_cluster_properties)
+)
 
-cluster_info_response = optic.get_alias_info(cluster_generator)
+alias_info = optic.get_alias_info([cluster])
 print("ALIAS INFORMATION")
 print(json.dumps(cluster_info_response, indent=3))
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensearch-optic"
-version = "1.5.1"
+version = "2.0.0"
 description = "Opensearch Tools for Indices and Clusters"
 readme = "README.md"
 authors = [

--- a/src/optic/__init__.py
+++ b/src/optic/__init__.py
@@ -1,6 +1,15 @@
 from optic.alias.alias_service import get_alias_info
-from optic.cluster.cluster_service import get_cluster_info
+from optic.cluster.cluster import Cluster, configure_cluster
+from optic.cluster.cluster_service import get_cluster_info, get_selected_clusters
 from optic.common.config import ClusterConfig
 from optic.index.index_service import get_index_info
 
-__all__ = ["get_cluster_info", "get_index_info", "get_alias_info", "ClusterConfig"]
+__all__ = [
+    "Cluster",
+    "ClusterConfig",
+    "configure_cluster",
+    "get_cluster_info",
+    "get_index_info",
+    "get_alias_info",
+    "get_selected_clusters",
+]

--- a/src/optic/alias/alias_service.py
+++ b/src/optic/alias/alias_service.py
@@ -9,16 +9,16 @@ from terminaltables import AsciiTable
 from optic.common.optic_color import OpticColor
 
 
-def get_alias_info(config_info) -> list:
+def get_alias_info(clusters) -> list:
     """
     Retrieves and packages Alias information into a list of dictionaries
 
-    :param ClusterConfig config_info: Cluster Configuration info object
+    :param list clusters: list of Cluster type objects
     :return: list of dictionaries containing alias information
     :rtype: list
     """
     alias_list = []
-    for cluster in config_info.selected_cluster_objects:
+    for cluster in clusters:
         alias_list.extend(cluster.alias_list)
 
     alias_dicts = []

--- a/src/optic/cli.py
+++ b/src/optic/cli.py
@@ -87,9 +87,11 @@ def cli(ctx, optic_settings_file):
     help="specify a non-default cluster configuration file",
     show_default=True,
 )
-def init(optic_settings_file, cluster_config_file):
+@click.pass_context
+def init(ctx, cluster_config_file):
     """Initialize OPTIC settings,  configuration, and shell completion"""
     try:
+        optic_settings_file = ctx.obj["optic_settings"]["optic_settings_file"]
         initialize_optic(optic_settings_file, cluster_config_file)
     except OpticError as e:
         print(e)

--- a/src/optic/cluster/cluster.py
+++ b/src/optic/cluster/cluster.py
@@ -44,7 +44,7 @@ class ClusterHealth:
 class Cluster:
     def __init__(
         self,
-        base_url=None,
+        url=None,
         auth=None,
         verify_ssl=True,
         name=None,
@@ -52,7 +52,7 @@ class Cluster:
         search_pattern=None,
         index_type_patterns=None,
     ):
-        self.base_url = base_url
+        self.url = url
         self.auth = auth
         self.verify_ssl = verify_ssl
         self.name = name
@@ -100,7 +100,7 @@ class Cluster:
         if not self._health:
             print("Getting cluster health for", self.name)
             api = OpenSearchAction(
-                base_url=self.base_url,
+                url=self.url,
                 usr=self.auth["username"],
                 pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
@@ -121,7 +121,7 @@ class Cluster:
         if not self._storage_percent:
             print("Getting storage percent for", self.name)
             api = OpenSearchAction(
-                base_url=self.base_url,
+                url=self.url,
                 usr=self.auth["username"],
                 pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
@@ -142,7 +142,7 @@ class Cluster:
         if not self._index_list:
             index_list = []
             api = OpenSearchAction(
-                base_url=self.base_url,
+                url=self.url,
                 usr=self.auth["username"],
                 pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
@@ -187,7 +187,7 @@ class Cluster:
         if not self._alias_list:
             alias_list = []
             api = OpenSearchAction(
-                base_url=self.base_url,
+                url=self.url,
                 usr=self.auth["username"],
                 pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,

--- a/src/optic/cluster/cluster.py
+++ b/src/optic/cluster/cluster.py
@@ -45,7 +45,7 @@ class Cluster:
     def __init__(
         self,
         base_url=None,
-        creds=None,
+        auth=None,
         verify_ssl=True,
         name=None,
         byte_type=None,  # remove this?
@@ -53,7 +53,7 @@ class Cluster:
         index_type_patterns=None,
     ):
         self.base_url = base_url
-        self.creds = creds
+        self.auth = auth
         self.verify_ssl = verify_ssl
         self.name = name
         self.byte_type = byte_type
@@ -101,8 +101,8 @@ class Cluster:
             print("Getting cluster health for", self.name)
             api = OpenSearchAction(
                 base_url=self.base_url,
-                usr=self.creds["username"],
-                pwd=self.creds["password"],
+                usr=self.auth["username"],
+                pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
                 query="/_cluster/health?pretty",
             )
@@ -122,8 +122,8 @@ class Cluster:
             print("Getting storage percent for", self.name)
             api = OpenSearchAction(
                 base_url=self.base_url,
-                usr=self.creds["username"],
-                pwd=self.creds["password"],
+                usr=self.auth["username"],
+                pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
                 query="/_cat/allocation?h=disk.used,disk.total&format=json&bytes=mb",
             )
@@ -143,8 +143,8 @@ class Cluster:
             index_list = []
             api = OpenSearchAction(
                 base_url=self.base_url,
-                usr=self.creds["username"],
-                pwd=self.creds["password"],
+                usr=self.auth["username"],
+                pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
                 query="/_cat/indices/"
                 + self.search_pattern
@@ -188,8 +188,8 @@ class Cluster:
             alias_list = []
             api = OpenSearchAction(
                 base_url=self.base_url,
-                usr=self.creds["username"],
-                pwd=self.creds["password"],
+                usr=self.auth["username"],
+                pwd=self.auth["password"],
                 verify_ssl=self.verify_ssl,
                 query="/_cat/aliases/" + self.search_pattern + "?format=json",
             )

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -6,28 +6,82 @@
 
 from terminaltables import AsciiTable
 
+from optic.cluster.cluster import Cluster
+from optic.common.exceptions import OpticConfigurationFileError
 from optic.common.optic_color import OpticColor
 
 
-def get_cluster_info(config_info) -> list:
+def get_selected_clusters(cluster_config, selected_cluster_names):
+    """
+    Given the optic cluster configuration and a list of cluster names,
+    return a list of Cluster type objects
+
+    :param ClusterConfig cluster_config: Cluster Configuration info object
+    :param list selected_cluster_names: list of cluster or cluster group names
+    :return: List of Cluster type objects
+    :rtype: list[Cluster]
+    """
+    selected_clusters = []
+
+    # Replaces cluster group names with associated clusters
+    if cluster_config.groups:
+        for group_name, group_clusters in cluster_config.groups.items():
+            if group_name in selected_cluster_names:
+                selected_cluster_names.extend(group_clusters)
+                selected_cluster_names.remove(group_name)
+
+    # Delete repeats
+    selected_cluster_names = list(set(selected_cluster_names))
+
+    # If no clusters are specified, use all clusters in the ClusterConfig
+    default_behavior = len(selected_cluster_names) == 0
+
+    # If a cluster name is in selected_clusters list, create a Cluster object to represent it
+    for cluster_name, cluster_data in cluster_config.clusters.items():
+        if (cluster_name in selected_cluster_names) or default_behavior:
+            do_ssl = cluster_data.get("verify_ssl", True)
+            if type(do_ssl) is not bool:
+                raise OpticConfigurationFileError(
+                    "Unrecognized SSL option for " + cluster_name
+                )
+            cluster = Cluster(
+                base_url=cluster_data["url"],
+                creds={
+                    "username": cluster_data["username"],
+                    "password": cluster_data["password"],
+                },
+                verify_ssl=do_ssl,
+                name=cluster_name,
+                # byte_type=self.settings['default_cluster_info_byte_type']
+            )
+
+            selected_clusters.append(cluster)
+            if selected_cluster_names:
+                selected_cluster_names.remove(cluster_name)
+
+    # Notifies if any non-existent clusters provided
+    for missing_cluster in selected_cluster_names:
+        print(missing_cluster, "is not present in cluster configuration file")
+    return selected_clusters
+
+
+def get_cluster_info(clusters) -> list:
     """
     Retrieves and packages Cluster information into a list of dictionaries
 
-    :param ClusterConfig config_info: Cluster Configuration info object
+    :param list clusters: list of Cluster type objects
     :return: list of dictionaries containing cluster information
     :rtype: list
     """
     cluster_info = []
-    for cluster in config_info.selected_cluster_objects:
+    for cluster in clusters:
         usage = cluster.storage_percent
         status = cluster.health.status
-        cluster_info.append(
-            {"name": cluster.custom_name, "status": status, "usage": usage}
-        )
+        cluster_info.append({"name": cluster.name, "status": status, "usage": usage})
     return cluster_info
 
 
-def print_cluster_info(cluster_info, no_color, storage_percent_thresholds) -> None:
+def print_cluster_info(cluster_info, optic_settings) -> None:
     """
     Prints cluster information
 
@@ -37,7 +91,11 @@ def print_cluster_info(cluster_info, no_color, storage_percent_thresholds) -> No
     :return: None
     :rtype: None
     """
-    table = build_cluster_info_table(cluster_info, no_color, storage_percent_thresholds)
+    table = build_cluster_info_table(
+        cluster_info,
+        optic_settings["no_color"],
+        optic_settings["storage_percent_thresholds"],
+    )
 
     # only display the table if at least one valid cluster was found
     if table:

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -46,7 +46,7 @@ def get_selected_clusters(cluster_config, selected_cluster_names):
                 )
             cluster = Cluster(
                 base_url=cluster_data["url"],
-                creds={
+                auth={
                     "username": cluster_data["username"],
                     "password": cluster_data["password"],
                 },

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -45,7 +45,7 @@ def get_selected_clusters(cluster_config, selected_cluster_names):
                     "Unrecognized SSL option for " + cluster_name
                 )
             cluster = Cluster(
-                base_url=cluster_data["url"],
+                url=cluster_data["url"],
                 auth={
                     "username": cluster_data["username"],
                     "password": cluster_data["password"],

--- a/src/optic/cluster/cluster_service.py
+++ b/src/optic/cluster/cluster_service.py
@@ -52,7 +52,6 @@ def get_selected_clusters(cluster_config, selected_cluster_names):
                 },
                 verify_ssl=do_ssl,
                 name=cluster_name,
-                # byte_type=self.settings['default_cluster_info_byte_type']
             )
 
             selected_clusters.append(cluster)

--- a/src/optic/common/api.py
+++ b/src/optic/common/api.py
@@ -22,7 +22,7 @@ urllib3.disable_warnings()
 class OpenSearchAction:
     def __init__(
         self,
-        base_url="",
+        url="",
         query="",
         retries=3,
         backoff_factor=2,
@@ -34,8 +34,8 @@ class OpenSearchAction:
         """
         Wraps the methods required to execute REST calls against the OpenSearch API.
         Args:
-            base_url (str): The URL to send the request to
-            query (str): additional string added to the end of base_url
+            url (str): The URL to send the request to
+            query (str): additional string added to the end of url
             retries (int): Maximum number of retries
             backoff_factor (float): Backoff factor to apply between retries in seconds
             status_forcelist (tuple): HTTP status codes to retry on
@@ -45,7 +45,7 @@ class OpenSearchAction:
 
         """
 
-        self.base_url = base_url
+        self.url = url
         self.query = query
         self.retries = retries
         self.backoff_factor = backoff_factor
@@ -69,7 +69,7 @@ class OpenSearchAction:
         """
 
         if not self._response:
-            url = self.base_url + self.query
+            url = self.url + self.query
             logging.debug(
                 f"creating REST request to {url} with "
                 f"{self.retries} retries, backoff {self.backoff_factor}, and ssl verify {self.verify_ssl}"

--- a/src/optic/common/config.py
+++ b/src/optic/common/config.py
@@ -32,8 +32,8 @@ def yaml_load(file_path) -> dict:
     return yaml_data
 
 
-def read_cluster_config(cluster_config_file):
-    return ClusterConfig(yaml_load(cluster_config_file))
+def read_cluster_config(cluster_config_file_path):
+    return ClusterConfig(yaml_load(cluster_config_file_path))
 
 
 class ClusterConfig:

--- a/src/optic/common/optic_color.py
+++ b/src/optic/common/optic_color.py
@@ -27,6 +27,7 @@ class OpticColor:
         :rtype: None
         """
         for attr, value in self.__dict__.items():
+            print(attr, value)
             if (
                 isinstance(value, str)
                 and value.startswith("\033[")

--- a/src/optic/index/index.py
+++ b/src/optic/index/index.py
@@ -13,13 +13,13 @@ from optic.common.exceptions import OpticDataError
 
 
 class IndexInfo:
-    def __init__(self, index_types_dict=None, **kwargs):
+    def __init__(self, index_type_patterns=None, **kwargs):
         self.index = None
         self.pri = None
         self._age = None
         self._shard_size = None
         self._index_type = None
-        self.index_types_dict = index_types_dict
+        self.index_type_patterns = index_type_patterns or {}
         self._set_properties_from_response(**kwargs)
 
     def _set_properties_from_response(self, **kwargs) -> None:
@@ -54,7 +54,7 @@ class IndexInfo:
         :return: index type string
         :rtype: str
         """
-        for type_name, reg_ex in self.index_types_dict.items():
+        for type_name, reg_ex in self.index_type_patterns.items():
             if re.match(reg_ex, self.index):
                 return type_name
         return "UNDEFINED"
@@ -143,13 +143,13 @@ class Index:
         cluster_name=None,
         index_name=None,
         write_alias=None,
-        index_types_dict=None,
+        index_type_patterns=None,
         info_response=None,
     ):
         self.cluster_name = cluster_name
         self.name = index_name
         self.write_alias = write_alias
-        self.index_types_dict = index_types_dict
+        self.index_type_patterns = index_type_patterns
         self.info_response = info_response
         self._info = None
 
@@ -163,6 +163,6 @@ class Index:
         """
         if not self._info:
             self._info = IndexInfo(
-                index_types_dict=self.index_types_dict, **self.info_response
+                index_type_patterns=self.index_type_patterns, **self.info_response
             )
         return self._info

--- a/src/optic/index/index_service.py
+++ b/src/optic/index/index_service.py
@@ -192,14 +192,14 @@ def filter_and_sort_indices(cluster_list, filters, sort_by) -> list:
     return index_list
 
 
-def get_index_info(config_info, filters=None, sort_by=None) -> list:
+def get_index_info(clusters, filters=None, sort_by=None) -> list:
     """
     Retrieves and packages Index information into a list of dictionaries
 
-    :param ClusterConfig config_info: Cluster Configuration info object
-    :param dict filters: dictionary with filter information
+    :param list clusters: list of Cluster type objects
+    :param dict filters: dictionary with filter configuration
     :param list sort_by: tuple with desired sort types
-    :return: list of dictionaries containing index information
+    :return: list of dictionaries containing cluster information
     :rtype: list
     """
     if filters is None:
@@ -217,9 +217,7 @@ def get_index_info(config_info, filters=None, sort_by=None) -> list:
         }
     if sort_by is None:
         sort_by = []
-    index_list = filter_and_sort_indices(
-        config_info.selected_cluster_objects, filters, sort_by
-    )
+    index_list = filter_and_sort_indices(clusters, filters, sort_by)
     index_dicts = []
     for index in index_list:
         index_dicts.append(

--- a/src/optic/initialize/initialize_service.py
+++ b/src/optic/initialize/initialize_service.py
@@ -22,43 +22,58 @@ SAMPLE_CLUSTER_CONFIG = """clusters:
     url: https://myurl.com:9200
     username: my_username2
     password: '****'
-  my_cluster:
-    url: https://onlineopensearchcluster.com:634
-    username: my_username3
-    password: '****'
   cluster_3:
     url: https://anotherurl.com:82
     username: my_username4
     password: '****'
+  cluster_4:
+    url: https://anotherurl2.com:82
+    username: my_username5
+    password: '****'
+  cluster_5:
+    url: https://anotherurl3.com:82
+    username: my_username6
+    password: '****'
+  my_cluster:
+    url: https://onlineopensearchcluster.com:634
+    username: my_username3
+    password: '****'
+  dev_cluster:
+    url: https://offlineopensearchcluster.com:634
+    username: my_username3
+    password: '****'
 
 groups:
-  my_group:
+  dev:
+    - my_cluster
+    - dev_cluster
+  stage:
     - cluster_1
     - cluster_2
     - cluster_3
-  g2:
-    - cluster_1
-    - my_cluster
+  production:
+    - cluster_4
+    - cluster_5
 
 """
 
 SAMPLE_SETTINGS = """# File Paths
-settings_file_path: ~/.optic/optic-settings.yaml
-default_cluster_config_file_path: ~/.optic/cluster-config.yaml
+# File Paths
+cluster_config_file: ~/.optic/cluster-config.yaml
 
 # Terminal Customization
 disable_terminal_color: False
 
 # Cluster Info Settings
-default_cluster_info_byte_type: gb
 storage_percent_thresholds:
   GREEN: 80
   YELLOW: 85
   RED: 100
 
 # Index/Alias Info Settings
-default_search_pattern: '*'
-default_index_type_patterns:
+byte_type: gb
+search_pattern: '*'
+index_type_patterns:
   ISM: '(.*)-ism-(\\d{6})$'
   ISM_MALFORMED: '(.*)-ism$'
   SYSTEM: '(^\\..*)$'
@@ -69,7 +84,7 @@ default_index_type_patterns:
 OPTIC_COLOR = OpticColor()
 
 
-def initialize_optic() -> None:
+def initialize_optic(optic_settings_file, cluster_config_file) -> None:
     """
     Initializes the Optic configuration by setting up the cluster configuration,
     default settings, and shell completion.
@@ -77,19 +92,19 @@ def initialize_optic() -> None:
     :return: None
     :rtype: None
     """
-    setup_cluster_config()
-    setup_settings()
+    setup_settings(optic_settings_file)
+    setup_cluster_config(cluster_config_file)
     setup_shell_completion()
 
 
-def setup_cluster_config() -> None:
+def setup_cluster_config(cluster_config_file) -> None:
     """
     Sets up sample cluster config file
 
     :return: None
     :rtype: None
     """
-    cluster_config_path = os.path.expanduser(f"{CONFIG_BASE_DIR}/cluster-config.yaml")
+    cluster_config_path = os.path.expanduser(cluster_config_file)
 
     # Prompts user for permission to create cluster config file if file does not exists
     if not validate_file_exists(cluster_config_path):
@@ -120,14 +135,14 @@ def setup_cluster_config() -> None:
         )
 
 
-def setup_settings() -> None:
+def setup_settings(optic_settings_file) -> None:
     """
     Sets up default settings file
 
     :return: None
     :rtype: None
     """
-    settings_file_path = os.path.expanduser(f"{CONFIG_BASE_DIR}/optic-settings.yaml")
+    settings_file_path = os.path.expanduser(optic_settings_file)
 
     # Prompts user for permission to create a settings file
     if not validate_file_exists(settings_file_path):

--- a/src/optic/initialize/initialize_service.py
+++ b/src/optic/initialize/initialize_service.py
@@ -59,7 +59,7 @@ groups:
 
 SAMPLE_SETTINGS = """# File Paths
 # File Paths
-cluster_config_file: ~/.optic/cluster-config.yaml
+cluster_config_file_path: ~/.optic/cluster-config.yaml
 
 # Terminal Customization
 disable_terminal_color: False
@@ -84,7 +84,7 @@ index_type_patterns:
 OPTIC_COLOR = OpticColor()
 
 
-def initialize_optic(optic_settings_file, cluster_config_file) -> None:
+def initialize_optic(optic_settings_file_path, cluster_config_file_path) -> None:
     """
     Initializes the Optic configuration by setting up the cluster configuration,
     default settings, and shell completion.
@@ -92,19 +92,19 @@ def initialize_optic(optic_settings_file, cluster_config_file) -> None:
     :return: None
     :rtype: None
     """
-    setup_settings(optic_settings_file)
-    setup_cluster_config(cluster_config_file)
+    setup_settings(optic_settings_file_path)
+    setup_cluster_config(cluster_config_file_path)
     setup_shell_completion()
 
 
-def setup_cluster_config(cluster_config_file) -> None:
+def setup_cluster_config(cluster_config_file_path) -> None:
     """
     Sets up sample cluster config file
 
     :return: None
     :rtype: None
     """
-    cluster_config_path = os.path.expanduser(cluster_config_file)
+    cluster_config_path = os.path.expanduser(cluster_config_file_path)
 
     # Prompts user for permission to create cluster config file if file does not exists
     if not validate_file_exists(cluster_config_path):
@@ -135,14 +135,14 @@ def setup_cluster_config(cluster_config_file) -> None:
         )
 
 
-def setup_settings(optic_settings_file) -> None:
+def setup_settings(optic_settings_file_path) -> None:
     """
     Sets up default settings file
 
     :return: None
     :rtype: None
     """
-    settings_file_path = os.path.expanduser(optic_settings_file)
+    settings_file_path = os.path.expanduser(optic_settings_file_path)
 
     # Prompts user for permission to create a settings file
     if not validate_file_exists(settings_file_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def optic_settings_file(optic_settings_file_path, cluster_config_file_path):
     with open(optic_settings_file_path, "w") as f:
         yaml.dump(
             {
-                "cluster_config_file": cluster_config_file_path,
+                "cluster_config_file_path": cluster_config_file_path,
                 "disable_terminal_color": False,
                 "search_pattern": "*",
                 "byte_type": "gb",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import tempfile
 import pytest
 import yaml
 
+from optic.common.config import ClusterConfig
+
 
 @pytest.fixture
 def temp_dir():
@@ -16,9 +18,18 @@ def temp_dir():
 
 @pytest.fixture
 def cluster_config_file_path(temp_dir):
-    settings_file_path = f"{temp_dir}/cluster-config.yaml"
+    return f"{temp_dir}/cluster-config.yaml"
 
-    with open(settings_file_path, "w") as f:
+
+@pytest.fixture
+def optic_settings_file_path(temp_dir):
+    return f"{temp_dir}/optic-settings.yaml"
+
+
+@pytest.fixture
+def cluster_config_file(cluster_config_file_path):
+
+    with open(cluster_config_file_path, "w") as f:
         yaml.dump(
             {
                 "clusters": {
@@ -55,43 +66,41 @@ def cluster_config_file_path(temp_dir):
             f,
         )
 
-    yield settings_file_path
+    yield cluster_config_file_path
 
 
 @pytest.fixture
-def optic_settings_file_path(temp_dir, cluster_config_file_path):
-    settings_file_path = f"{temp_dir}/optic-settings.yaml"
+def optic_settings_file(optic_settings_file_path, cluster_config_file_path):
 
-    with open(settings_file_path, "w") as f:
+    with open(optic_settings_file_path, "w") as f:
         yaml.dump(
             {
-                "default_cluster_config_file_path": cluster_config_file_path,
-                "default_cluster_info_byte_type": "gb",
-                "default_index_type_patterns": {
+                "cluster_config_file": cluster_config_file_path,
+                "disable_terminal_color": False,
+                "search_pattern": "*",
+                "byte_type": "gb",
+                "storage_percent_thresholds": {"GREEN": 80, "RED": 100, "YELLOW": 85},
+                "index_type_patterns": {
                     "DATED": r"(.*)-(\d{4})\.(\d{2})\.(\d{2})$",
                     "ISM": r"(.*)-ism-(\d{6})$",
                     "ISM_MALFORMED": "(.*)-ism$",
                     "STATIC": "(.*)_static(.*)$",
                     "SYSTEM": r"(^\..*)$",
                 },
-                "default_search_pattern": "*",
-                "disable_terminal_color": False,
-                "settings_file_path": {settings_file_path},
-                "storage_percent_thresholds": {"GREEN": 80, "RED": 100, "YELLOW": 85},
             },
             f,
         )
 
-    yield settings_file_path
+    yield optic_settings_file_path
 
 
 @pytest.fixture
-def optic_settings(optic_settings_file_path) -> dict:
-    with open(optic_settings_file_path, "r") as f:
+def optic_settings(optic_settings_file) -> dict:
+    with open(optic_settings_file, "r") as f:
         return yaml.safe_load(f)
 
 
 @pytest.fixture
-def cluster_config(cluster_config_file_path) -> dict:
-    with open(cluster_config_file_path, "r") as f:
-        return yaml.safe_load(f)
+def cluster_config(cluster_config_file) -> dict:
+    with open(cluster_config_file, "r") as f:
+        return ClusterConfig(yaml.safe_load(f))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ class TestOpenSearchActionClass:
         mock_response.status_code = 200
         mock_response.json.return_value = {"request": "valid"}
 
-        api = OpenSearchAction(base_url="http://example.com/optic")
+        api = OpenSearchAction(url="http://example.com/optic")
         mocker.patch("requests.Session.get", return_value=mock_response)
 
         assert api.response == {"request": "valid"}
@@ -63,7 +63,7 @@ class TestOpenSearchActionClass:
             patch("time.sleep", side_effect=_patched_sleep),
         ):
             action = OpenSearchAction(
-                base_url="http://example.com/optic",
+                url="http://example.com/optic",
                 retries=5,
                 backoff_factor=backoff_factor,
             )
@@ -109,7 +109,7 @@ class TestOpenSearchActionClass:
 
             with pytest.raises(OpticAPIError) as exc_info:
                 action = OpenSearchAction(
-                    base_url="http://example.com/optic",
+                    url="http://example.com/optic",
                     retries=retries,  # force exhaustion
                 )
                 _ = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from optic.cli import alias, cli, cluster, default_from_settings, index, init
+from optic.cli import alias, cli, cluster, get_default_from_optic_settings, index, init
 
 
 @pytest.fixture
@@ -212,28 +212,28 @@ class TestCli:
         runner.invoke(cli, ["init"])
         mock_initialize_optic.assert_called_once()
 
-    def test_option_default_from_settings_absent(self, ctx_obj):
+    def test_option_get_default_from_optic_settings_absent(self, ctx_obj):
         context = click.Context(cli.commands["alias"].commands["info"], obj=ctx_obj)
-        option_class = default_from_settings("example_setting")
+        option_class = get_default_from_optic_settings("example_setting")
         option = option_class(["--example"], required=False)
         with pytest.raises(SystemExit) as e:
             option.get_default(context)
         assert e.type == SystemExit
         assert e.value.code == 1
 
-    def test_option_default_from_settings_no_obj(self):
+    def test_option_get_default_from_optic_settings_no_obj(self):
         context = click.Context(cli.commands["alias"].commands["info"], obj=None)
-        option_class = default_from_settings("example_setting")
+        option_class = get_default_from_optic_settings("example_setting")
         option = option_class(["--example"], required=False)
         default_value = option.get_default(context)
         assert default_value is None
 
-    def test_option_default_from_settings_present(self):
+    def test_option_get_default_from_optic_settings_present(self):
         mock_settings = {"optic_settings": {"example_setting": "test_value"}}
         context = click.Context(
             cli.commands["alias"].commands["info"], obj=mock_settings
         )
-        option_class = default_from_settings("example_setting")
+        option_class = get_default_from_optic_settings("example_setting")
         option = option_class(["--example"], required=False)
         default_value = option.get_default(context)
         assert default_value == "test_value"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,9 @@ from optic.cli import alias, cli, cluster, default_from_settings, index, init
 
 
 @pytest.fixture
-def ctx_obj(optic_settings_file_path):
-    yield {"settings_file_path": optic_settings_file_path}
+def ctx_obj(optic_settings_file_path, optic_settings):
+    optic_settings["optic_settings_file"] = optic_settings_file_path
+    yield {"optic_settings": optic_settings}
 
 
 @pytest.fixture
@@ -23,21 +24,37 @@ def mock_exit(mocker):
 
 
 class TestCli:
-    @pytest.mark.parametrize("command", [alias, cli, cluster, index, init])
+    @pytest.mark.parametrize("command", [cli, init, cluster, index, alias])
     def test_commands_help(self, runner, command):
         result = runner.invoke(command, ["--help"])
         assert result.exit_code == 0
         assert "Usage:" in result.output
 
-    def test_alias_tool_fail(self, runner, mock_exit):
+    def test_alias_info_tool_missing_cluster_config_file(
+        self, runner, optic_settings_file_path, mock_exit
+    ):
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
+                optic_settings_file_path,
+                "alias",
+                "info",
+                "--cluster-config-file",
+                "dummy.yml",
+            ],
+        )
+        mock_exit.assert_called_once_with(1)
+
+    def test_alias_info_tool_missing_both_yaml_files(self, runner, mock_exit):
+        runner.invoke(
+            cli,
+            [
+                "--optic-settings-file",
                 "non-existing-settings.yaml",
                 "alias",
                 "info",
-                "--cluster-config",
+                "--cluster-config-file",
                 "dummy.yml",
             ],
         )
@@ -51,47 +68,40 @@ class TestCli:
             in result.output
         )
 
-    def test_alias_info_command_fail(self, runner, optic_settings_file_path, mock_exit):
-        runner.invoke(
-            cli,
-            [
-                "--settings",
-                optic_settings_file_path,
-                "alias",
-                "info",
-                "--cluster-config",
-                "dummy.yml",
-            ],
-        )
-        mock_exit.assert_called_once_with(1)
-
-    def test_alias_info_command_success(self, mocker, runner, optic_settings_file_path):
-        mock_cluster_config_class = mocker.patch("optic.cli.ClusterConfig")
+    def test_alias_info_command_success(
+        self,
+        mocker,
+        runner,
+        optic_settings_file_path,
+        optic_settings_file,
+        cluster_config_file,
+    ):
+        mock_get_selected_clusters = mocker.patch("optic.cli.get_selected_clusters")
         mock_get_alias_info = mocker.patch("optic.cli.get_alias_info")
 
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 optic_settings_file_path,
                 "alias",
                 "info",
-                "--clusters",
+                "--cluster",
                 "cluster_1",
             ],
         )
-        mock_cluster_config_class.assert_called_once()
+        mock_get_selected_clusters.assert_called_once()
         mock_get_alias_info.assert_called_once()
 
     def test_cluster_tool_fail(self, runner, mock_exit):
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 "non-existing-settings.yaml",
                 "cluster",
                 "info",
-                "--cluster-config",
+                "--cluster-config-file",
                 "dummy.yml",
             ],
         )
@@ -103,88 +113,103 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 optic_settings_file_path,
                 "cluster",
                 "info",
-                "--cluster-config",
+                "--cluster-config-file",
                 "dummy.yml",
             ],
         )
         mock_exit.assert_called_once_with(1)
 
     def test_cluster_info_command_success(
-        self, mocker, runner, optic_settings_file_path
+        self, mocker, runner, optic_settings_file_path, optic_settings, cluster_config
     ):
-        mock_cluster_config_class = mocker.patch("optic.cli.ClusterConfig")
+        mock_get_selected_clusters = mocker.patch("optic.cli.get_selected_clusters")
         mock_get_cluster_info = mocker.patch("optic.cli.get_cluster_info")
 
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 optic_settings_file_path,
                 "cluster",
                 "info",
-                "--clusters",
+                "--cluster",
                 "cluster_1",
             ],
         )
-        mock_cluster_config_class.assert_called_once()
+        mock_get_selected_clusters.assert_called_once()
         mock_get_cluster_info.assert_called_once()
 
-    def test_index_tool_fail(self, runner, mock_exit):
+    def test_alias_info_tool_missing_both_yaml_files(self, runner, mock_exit):
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 "non-existing-settings.yaml",
                 "index",
                 "info",
-                "--cluster-config",
+                "--cluster-config-file",
                 "dummy.yml",
             ],
         )
         mock_exit.assert_called_once_with(1)
 
-    def test_index_info_command_fail(
-        self, mocker, runner, optic_settings_file_path, mock_exit
+    def test_alias_info_tool_missing_cluster_config_file(
+        self,
+        mocker,
+        runner,
+        optic_settings_file_path,
+        optic_settings_file,
+        mock_exit,
     ):
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 optic_settings_file_path,
                 "index",
                 "info",
-                "--cluster-config",
+                "--cluster-config-file",
                 "dummy.yml",
             ],
         )
         mock_exit.assert_called_once_with(1)
 
-    def test_index_info_command_success(self, mocker, runner, optic_settings_file_path):
-        mock_cluster_config_class = mocker.patch("optic.cli.ClusterConfig")
+    def test_index_info_command_success(
+        self,
+        mocker,
+        runner,
+        optic_settings_file_path,
+        optic_settings_file,
+        cluster_config_file,
+    ):
+        mock_configure_cluster = mocker.patch("optic.cli.configure_cluster")
         mock_get_index_info = mocker.patch("optic.cli.get_index_info")
+        mock_print_index_info = mocker.patch("optic.cli.print_index_info")
 
         runner.invoke(
             cli,
             [
-                "--settings",
+                "--optic-settings-file",
                 optic_settings_file_path,
                 "index",
                 "info",
-                "--clusters",
+                "--cluster",
                 "cluster_1",
+                "--cluster",
+                "cluster_2",
             ],
         )
-        mock_cluster_config_class.assert_called_once()
+        assert mock_configure_cluster.call_count == 2
         mock_get_index_info.assert_called_once()
+        mock_print_index_info.assert_called_once()
 
     def test_init_command_success(self, mocker, runner):
         mock_initialize_optic = mocker.patch("optic.cli.initialize_optic")
-
-        runner.invoke(init)
+        runner.invoke(cli, ["init"])
         mock_initialize_optic.assert_called_once()
 
     def test_option_default_from_settings_absent(self, ctx_obj):
@@ -204,7 +229,7 @@ class TestCli:
         assert default_value is None
 
     def test_option_default_from_settings_present(self):
-        mock_settings = {"example_setting": "test_value"}
+        mock_settings = {"optic_settings": {"example_setting": "test_value"}}
         context = click.Context(
             cli.commands["alias"].commands["info"], obj=mock_settings
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from optic.cli import alias, cli, cluster, default_from_settings, index, init
 
 @pytest.fixture
 def ctx_obj(optic_settings_file_path, optic_settings):
-    optic_settings["optic_settings_file"] = optic_settings_file_path
+    optic_settings["optic_settings_file_path"] = optic_settings_file_path
     yield {"optic_settings": optic_settings}
 
 
@@ -36,11 +36,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "alias",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -50,11 +50,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 "non-existing-settings.yaml",
                 "alias",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -82,7 +82,7 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "alias",
                 "info",
@@ -97,11 +97,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 "non-existing-settings.yaml",
                 "cluster",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -113,11 +113,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "cluster",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -132,7 +132,7 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "cluster",
                 "info",
@@ -147,11 +147,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 "non-existing-settings.yaml",
                 "index",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -168,11 +168,11 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "index",
                 "info",
-                "--cluster-config-file",
+                "--cluster-config",
                 "dummy.yml",
             ],
         )
@@ -193,7 +193,7 @@ class TestCli:
         runner.invoke(
             cli,
             [
-                "--optic-settings-file",
+                "--settings",
                 optic_settings_file_path,
                 "index",
                 "info",

--- a/tests/test_index_info.py
+++ b/tests/test_index_info.py
@@ -4,7 +4,6 @@ import dateutil.parser
 import pytest
 
 from optic.cluster.cluster import Cluster
-from optic.common.config import ClusterConfig
 from optic.common.exceptions import OpticDataError
 from optic.index.index import Index
 from optic.index.index_service import (
@@ -46,8 +45,7 @@ class TestIndexService:
         parse_bytes_exception_cases()
 
     def test_get_index_info(self):
-        config_info = ClusterConfig({}, [], {})
-        test_cluster = Cluster(custom_name="test_cluster")
+        test_cluster = Cluster(name="test_cluster")
         test_cluster._index_list = []
         sim_response = {
             "health": "yellow",
@@ -62,17 +60,15 @@ class TestIndexService:
             "pri.store.size": "954kb",
             "creation.date.string": "2024-06-04T15:17:41.806Z",
         }
-        test_index_types = {"STOCK": "(.*)ocki(.*)$"}
+        test_index_type_patterns = {"STOCK": "(.*)ocki(.*)$"}
         test_index = Index(
             cluster_name="test_cluster",
-            index_types_dict=test_index_types,
+            index_type_patterns=test_index_type_patterns,
             info_response=sim_response,
         )
         test_cluster._index_list.append(test_index)
 
-        test_cluster_list = [test_cluster]
-        config_info._selected_cluster_objects = test_cluster_list
-        dict_response = get_index_info(config_info)
+        dict_response = get_index_info([test_cluster])
         assert dict_response[0]["name"] == "stockindex"
         assert (
             dict_response[0]["age"]

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -42,7 +42,9 @@ def mock_shell_configuration_file_path(temp_dir):
 
 class TestInitialize:
 
-    def test_initialize_optic(self, mocker):
+    def test_initialize_optic(
+        self, mocker, optic_settings_file_path, cluster_config_file_path
+    ):
         # Mock setup_cluster_config, setup_settings, and setup_shell_completion
         mock_setup_cluster_config = mocker.patch(
             "optic.initialize.initialize_service.setup_cluster_config"
@@ -54,61 +56,54 @@ class TestInitialize:
             "optic.initialize.initialize_service.setup_shell_completion"
         )
 
-        initialize_optic()
+        initialize_optic(optic_settings_file_path, cluster_config_file_path)
 
         # Check if the mocked functions were called
         mock_setup_cluster_config.assert_called_once()
         mock_setup_settings.assert_called_once()
         mock_setup_shell_completion.assert_called_once()
 
-    def test_setup_cluster_config_file_create(self, mocker, temp_dir):
-        mock_dir = f"{temp_dir}/optic"
-        mocker.patch.object(initialize_service, "CONFIG_BASE_DIR", mock_dir)
+    def test_setup_cluster_config_file_create(self, mocker, cluster_config_file_path):
 
         # Mock "Y" input
         mocker.patch(
             "optic.initialize.initialize_service.prompt_question", return_value=True
         )
 
-        setup_cluster_config()
+        setup_cluster_config(cluster_config_file_path)
 
         # Assert cluster_config file was created
-        assert validate_file_exists(f"{mock_dir}/cluster-config.yaml")
+        assert validate_file_exists(cluster_config_file_path)
 
     def test_setup_cluster_config_file_exists(
-        self, mocker, cluster_config_file_path, temp_dir, capsys
+        self, cluster_config_file_path, capsys, cluster_config_file
     ):
-        mocker.patch.object(initialize_service, "CONFIG_BASE_DIR", temp_dir)
-
-        setup_cluster_config()
+        setup_cluster_config(cluster_config_file_path)
 
         captured = capsys.readouterr()
+        print(captured)
         assert (
             f"Cluster configuration file: {OPTIC_COLOR.OK_CYAN}{cluster_config_file_path}{OPTIC_COLOR.STOP} "
             "already exists" in captured.out
         )
 
-    def test_setup_settings_file_create(self, mocker, temp_dir):
-        mock_dir = f"{temp_dir}/optic"
-        mocker.patch.object(initialize_service, "CONFIG_BASE_DIR", mock_dir)
+    def test_setup_settings_file_create(self, mocker, optic_settings_file_path):
 
         # Mock "Y" input
         mocker.patch(
             "optic.initialize.initialize_service.prompt_question", return_value=True
         )
 
-        setup_settings()
+        setup_settings(optic_settings_file_path)
 
         # Assert settings file was created
-        assert validate_file_exists(f"{mock_dir}/optic-settings.yaml")
+        assert validate_file_exists(optic_settings_file_path)
 
     def test_setup_settings_file_exists(
-        self, mocker, optic_settings_file_path, temp_dir, capsys
+        self, optic_settings_file_path, capsys, optic_settings_file
     ):
-        mocker.patch.object(initialize_service, "CONFIG_BASE_DIR", temp_dir)
 
-        setup_settings()
-
+        setup_settings(optic_settings_file_path)
         captured = capsys.readouterr()
         assert (
             f"Settings file: {OPTIC_COLOR.OK_CYAN}{optic_settings_file_path}{OPTIC_COLOR.STOP} already exists"
@@ -213,7 +208,11 @@ class TestInitialize:
         assert "Shell completion is already setup" in captured.out
 
     def test_validate_file_exists_success(
-        self, cluster_config_file_path, optic_settings_file_path
+        self,
+        cluster_config_file_path,
+        optic_settings_file_path,
+        optic_settings_file,
+        cluster_config_file,
     ):
         assert validate_file_exists(cluster_config_file_path)
         assert validate_file_exists(optic_settings_file_path)


### PR DESCRIPTION
# Description

This is a major refactor of the Optic codebase. This was originally motivated by wanting to remove CLI options that were not intended for the end-user application. At the same time, there was previously no way of storing settings/preferences in the `optic-settings.yaml` file and then accessing them from within the codebase. These fixes, and more, have been included in this 💥Breaking Change💥with the intention of improving both the end-user and developer experience. 

* fix:! 🗑️ remove CLI options that were not intended for CLI interface
  * storage_percent_thresholds
  * index_type_patterns
* feat: 🚸 cli defaults now show settings defined in optic-settings.yaml
* feat: 🚸 optic init now allows for specifying custom destination for created configuration files
* refactor: 🚸 rename Cluster attribute `creds` to `auth`
* refactor: 🚸 shorten OpenSearchAction attribute `base_url` to `url`
* refactor: 🏗️ Cluster objects are updated with all optic-settings, instead of only cli options
  * enables additional configuration options in `optic-settings.yaml` that are not part of cli
* refactor: 🏗️ `get_cluster_info`, `get_index_info`, `get_alias_info` now use `Cluster` object as argument instead of ClusterConfig
* refactor: 🧑‍💻 shorten Cluster object `custom_name` attribute to `name`
* refactor: 🧑‍💻 `Settings` class renamed to `OpticSettings` to align with filename and `ClusterConfig` class name 
* refactor: 🧑‍💻 `index_type_dict` attribute in `IndexInfo` object renamed to `index_type_patterns` to match configuration setting

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update (completed as part of this change)

# How Has This Been Tested?

All previously existing unit-tests have been updated to support the new object attributes and CLI options. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
