### PR TITLE
ci: 👷 Macaron check-github-actions

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   code_quality:
     name: Linting
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -42,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -65,12 +68,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # This will fetch all tags
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,37 @@
+name: Macaron check-github-actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "20 15 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron policy verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: https://github.com/${{ github.repository }}
+          policy_file: check-github-actions
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Copyright (c) 2024-2025, Oracle and/or its affiliates. All rights reserved.
 All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 2.0.1
+* ci: 👷 Macaron check-github-actions
+* style: 🎨 Fit noqa S105 to black standard
+* test: 👷 noqa S105 for tests
+
+
 # 2.0.0
 * fix:! 💥 Breaking Change 💥 remove CLI options that were not intended for CLI interface
   * storage_percent_thresholds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the OPTIC project will be documented in
 this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 # 2.0.1
+* ci: 👷 Remediate Macaron findings
 * ci: 👷 Macaron check-github-actions
 * style: 🎨 Fit noqa S105 to black standard
 * test: 👷 noqa S105 for tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensearch-optic"
-version = "2.0.0"
+version = "2.0.1"
 description = "Opensearch Tools for Indices and Clusters"
 readme = "README.md"
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,22 +36,22 @@ def cluster_config_file(cluster_config_file_path):
                     "cluster_1": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "my_password", # noqa: S105
+                        "password": "my_password",  # noqa: S105
                     },
                     "cluster_2": {
                         "url": "https://myurl.com:9200",
                         "username": "my_username2",
-                        "password": "****", # noqa: S105
+                        "password": "****",  # noqa: S105
                     },
                     "my_cluster": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "****", # noqa: S105
+                        "password": "****",  # noqa: S105
                     },
                     "cluster_3": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "****", # noqa: S105
+                        "password": "****",  # noqa: S105
                     },
                 },
                 "groups": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,22 +36,22 @@ def cluster_config_file(cluster_config_file_path):
                     "cluster_1": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "my_password",
+                        "password": "my_password", # noqa: S105
                     },
                     "cluster_2": {
                         "url": "https://myurl.com:9200",
                         "username": "my_username2",
-                        "password": "****",
+                        "password": "****", # noqa: S105
                     },
                     "my_cluster": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "****",
+                        "password": "****", # noqa: S105
                     },
                     "cluster_3": {
                         "url": "https://testurl.com:46",
                         "username": "my_username1",
-                        "password": "****",
+                        "password": "****", # noqa: S105
                     },
                 },
                 "groups": {


### PR DESCRIPTION
 ## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Required follow-up
- Enable `Macaron policy verification` as a required status check for protected branches
- Resolve any policy findings before merge if applicable